### PR TITLE
Update to use new 'can_connect' method instead of 'is_ready'

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -209,7 +209,7 @@ class PortainerAgentCharm(CharmBase):
         # get a reference to the portainer workload container
         agent_name = self.app.name
         container = self.unit.get_container(agent_name)
-        if container.is_ready():
+        if container.can_connect():
             svc = container.get_services().get(agent_name, None)
             # check if the pebble service is already running
             if svc:
@@ -280,7 +280,7 @@ class PortainerAgentCharm(CharmBase):
         # Get a reference to the portainer workload container
         agent_name = "portainer-agent"
         container = self.unit.get_container(agent_name)
-        with container.is_ready():
+        if container.can_connect():
             svc = container.get_services().get(agent_name, None)
             # Check if the service is already running
             if not svc:


### PR DESCRIPTION
Due to a recent change in the Operator Framework [PR#605](https://github.com/canonical/operator/pull/605), the `is_ready` method is now renamed `can_connect`. There are some more details in the linked PR, but in this case the use of `is_ready` meant this is a trivial change.